### PR TITLE
fix wrong confidence interval shape in mt_coherence()

### DIFF
--- a/mtspec/multitaper.py
+++ b/mtspec/multitaper.py
@@ -600,7 +600,7 @@ def mt_coherence(df, xi, xj, tbp, kspec, nf, p, **kwargs):
                 'cohe_ci', 'phase_ci', 'iadapt'):
         kwargs.setdefault(key, None)
         if key in ('cohe_ci', 'phase_ci') and kwargs[key]:
-            kwargs[key] = mt.empty(nf, 2)
+            kwargs[key] = mt.empty((nf, 2))
             args.append(mt.p(kwargs[key]))
         elif key == 'iadapt' and kwargs[key]:
             args.append(C.byref(C.c_int(kwargs[key])))


### PR DESCRIPTION
In `multitaper.py`, the `mt_coherence()` function assigned an empty array
for the desired confidence interval using `mt.empty(nf, 2)` at line 600.
This gave an 1d complex array of length nf, because the argument `2` is passed
to the `complex=False` kwarg of the `mt.empty()` method.

The correct call should be `mt.empty((nf, 2))`

Related to issue https://github.com/krischer/mtspec/issues/32